### PR TITLE
Adding variable and sampling frequency tables and improving script speed.

### DIFF
--- a/update-reports/mk_report2.py
+++ b/update-reports/mk_report2.py
@@ -306,7 +306,7 @@ def gen_tables(project, time_shade):
 
 	Variables_TXT = "Number of variables from each model in support of each CMIP6 activity."
 
-	Models_per_freq_TXT = "Number of models from each sampling frequency in support of each CMIP6 activity."
+	Models_per_freq_TXT = "Number of models providing output at each sampling frequency in support of each CMIP6 activity."
 
 	timestamp = datetime.datetime.now().strftime("%A %d %B %Y %H:%M:%S")
 	headstr = "ESGF CMIP6 data holdings as of {}"


### PR DESCRIPTION
PCMDI/pcmdi.github.io#246

These changes add tables for the number of variables for each activity, and the number of models for each sampling frequency and activity.  These changes also enhance the speed of the mk_report2.py script by directly querying Solr rather than using the ESGF search API.